### PR TITLE
Remove colon for board name and list name

### DIFF
--- a/lib/ruboty/trello.rb
+++ b/lib/ruboty/trello.rb
@@ -8,7 +8,7 @@ end
 module Ruboty
   module Handlers
     class Trello < Base
-      on /:trello :b (?<board_name>.*) :l (?<list_name>.*) (?<name>.*)\z/i, name: 'trello', description: 'Add card to Trello'
+      on /:trello b (?<board_name>.*) l (?<list_name>.*) (?<name>.*)\z/i, name: 'trello', description: 'Add card to Trello'
 
       def trello(message)
         me = ::Trello::Member.find('me')


### PR DESCRIPTION
`:b`が絵文字になってしまうのが辛いので、`:`を`:b`と`:l`から取りました〜
