### PR TITLE
Add optional due date

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Or install it yourself as:
 @ruboty trello b <board_name> l <list_name> (lb <label_name>) (dd <due_date>) c <card_name>
 ```
 
+e.g.
+
+
+```
+@ruboty trello b development l icebox c something
+@ruboty trello b development l icebox dd 2016-01-01 c something
+@ruboty trello b development l icebox dd 2016-01-01 01:02 c something
+```
+
+
 ## ENV
 
 ### required
@@ -40,17 +50,6 @@ see https://github.com/jeremytregunna/ruby-trello#configuration to get these key
 ```
 TRELLO_AUTO_ASSIGN - If set to '1', assigns sender with created card
 TRELLO_RESPONSE_PREFIX - Specify response message (default is 'Created')
-```
-
-## Valid Value
-### dd \<due_date\>
-`YYYY-MM-DD` or `YYYY-MM-DD HH:MM`
-
-Example
-
-```
-dd 2016-01-01
-dd 2016-01-01 01:02
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ e.g.
 @ruboty trello b development l icebox c something
 @ruboty trello b development l icebox dd 2016-01-01 c something
 @ruboty trello b development l icebox dd 2016-01-01 01:02 c something
+@ruboty trello b development l icebox lb feature dd 2016-01-01 01:02 c something
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or install it yourself as:
 ## Usage
 
 ```
-@ruboty trello b <board_name> l <list_name> (lb <label_name>) c <card_name>
+@ruboty trello b <board_name> l <list_name> (lb <label_name>) (dt <due_time>) c <card_name>
 ```
 
 ## ENV

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or install it yourself as:
 ## Usage
 
 ```
-@ruboty trello b <board_name> l <list_name> (lb <label_name>) (dt <due_time>) c <card_name>
+@ruboty trello b <board_name> l <list_name> (lb <label_name>) (dd <due_date>) c <card_name>
 ```
 
 ## ENV

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ TRELLO_AUTO_ASSIGN - If set to '1', assigns sender with created card
 TRELLO_RESPONSE_PREFIX - Specify response message (default is 'Created')
 ```
 
+## Valid Value
+### dd \<due_date\>
+`YYYY-MM-DD` or `YYYY-MM-DD HH:MM`
+
+Example
+
+```
+dd 2016-01-01
+dd 2016-01-01 01:02
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/bitjourney/ruboty-trello/fork )

--- a/lib/ruboty/trello.rb
+++ b/lib/ruboty/trello.rb
@@ -8,7 +8,7 @@ end
 module Ruboty
   module Handlers
     class Trello < Base
-      on /trello\s+b\s+(?<board_name>.*?)\s+l\s+(?<list_name>.*?)\s+(lb\s+(?<label_name>.*?)\s+)?c\s+(?<name>.*)\z/i, name: 'trello', description: 'Add card to Trello'
+      on /trello\s+b\s+(?<board_name>.*?)\s+l\s+(?<list_name>.*?)\s+(lb\s+(?<label_name>.*?)\s+)?(dt\s+(?<due_time>.*?)\s+)?c\s+(?<name>.*)\z/, name: 'trello', description: 'Add card to Trello'
 
       def trello(message)
         me = ::Trello::Member.find('me')
@@ -37,7 +37,9 @@ module Ruboty
           member_id = member&.id
         end
 
-        new_card = ::Trello::Card.create(name: message[:name], list_id: list.id, card_labels: label_id, member_ids: member_id)
+        iso8601_time = Time.parse(message[:due_time]).iso8601 rescue nil
+
+        new_card = ::Trello::Card.create(name: message[:name], list_id: list.id, card_labels: label_id, member_ids: member_id, due: iso8601_time)
         if new_card.short_url
           prefix = ENV['TRELLO_RESPONSE_PREFIX'] || 'Created'
           message.reply "#{prefix} #{new_card.short_url}"

--- a/lib/ruboty/trello.rb
+++ b/lib/ruboty/trello.rb
@@ -8,7 +8,7 @@ end
 module Ruboty
   module Handlers
     class Trello < Base
-      on /trello\s+b\s+(?<board_name>.*?)\s+l\s+(?<list_name>.*?)\s+(lb\s+(?<label_name>.*?)\s+)?(dt\s+(?<due_time>.*?)\s+)?c\s+(?<name>.*)\z/, name: 'trello', description: 'Add card to Trello'
+      on /trello\s+b\s+(?<board_name>.*?)\s+l\s+(?<list_name>.*?)\s+(lb\s+(?<label_name>.*?)\s+)?(dd\s+(?<due_date>.*?)\s+)?c\s+(?<name>.*)\z/, name: 'trello', description: 'Add card to Trello'
 
       def trello(message)
         me = ::Trello::Member.find('me')
@@ -37,7 +37,7 @@ module Ruboty
           member_id = member&.id
         end
 
-        iso8601_time = Time.parse(message[:due_time]).iso8601 rescue nil
+        iso8601_time = Time.parse(message[:due_date]).iso8601 rescue nil
 
         new_card = ::Trello::Card.create(name: message[:name], list_id: list.id, card_labels: label_id, member_ids: member_id, due: iso8601_time)
         if new_card.short_url


### PR DESCRIPTION
I want to set due date, because my task often sets due date.

[Trello can set a due date.](http://help.trello.com/article/794-adding-due-dates-to-cards)
api also exists. [api reference](https://developers.trello.com/advanced-reference/card#put-1-cards-card-id-or-shortlink-due)
 
I implemented option that can set due date.

Please check PR 🙏 