### PR TITLE
Trello member from sender mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ see https://github.com/jeremytregunna/ruby-trello#configuration to get these key
 ```
 TRELLO_AUTO_ASSIGN - If set to '1', assigns sender with created card
 TRELLO_RESPONSE_PREFIX - Specify response message (default is 'Created')
+TRELLO_MEMBER_FROM_SENDER - JSON for sender to Trello member mapping (ex: {"ihara":"masahiroihara", "taro":"taroyamada"})
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ TRELLO_RESPONSE_PREFIX - Specify response message (default is 'Created')
 TRELLO_MEMBER_FROM_SENDER - JSON for sender to Trello member mapping (ex: {"ihara":"masahiroihara", "taro":"taroyamada"})
 ```
 
+## How to develop
+
+You have to set TRELO_DEVELOPER_PUBLIC_KEY and TRELLO_MEMBER_TOKEN, set other environment variables if you need. 
+```
+>  TRELLO_DEVELOPER_PUBLIC_KEY=xxx TRELLO_MEMBER_TOKEN=xxx bundle exec ruboty -l lib/rutoby/trello.rb
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/bitjourney/ruboty-trello/fork )

--- a/lib/ruboty/trello.rb
+++ b/lib/ruboty/trello.rb
@@ -43,17 +43,16 @@ module Ruboty
       end
 
       def find_member(members, sender)
+        # SlackのDisplay NameとTrelloのUsernameのマッピング
         senders_to_members = {}
         if ENV['TRELLO_MEMBER_FROM_SENDER']
           senders_to_members = JSON.parse(ENV['TRELLO_MEMBER_FROM_SENDER'])
         end
         members.find do |member|
-          # SlackのDisplay nameとTrelloのUsername（username）のマッピングと一致
-          return member if member.username.downcase == senders_to_members[sender]
-          # TrelloのUsername（username）と一致
-          return member if member.username.downcase == sender
-          # AtlassianのPublic Name（full_name）と一致
-          return member if member.full_name.downcase == sender
+          # sender: SlackのDisplay Name
+          # member.username: TrelloのUsername
+          # member.full_name: AtlassianのPublic Name
+          member.username.downcase == senders_to_members[sender] || member.username.downcase == sender || member.full_name.downcase == sender
         end
       end
     end

--- a/lib/ruboty/trello.rb
+++ b/lib/ruboty/trello.rb
@@ -31,9 +31,7 @@ module Ruboty
         member_id = nil
         if ENV['TRELLO_AUTO_ASSIGN'] && message.from_name
           sender = message.from_name.downcase
-          member = board.members.find do |member|
-            member.username.downcase == sender || member.full_name.downcase.include?(sender)
-          end
+          member = find_member(board.members, sender)
           member_id = member&.id
         end
 
@@ -41,6 +39,21 @@ module Ruboty
         if new_card.short_url
           prefix = ENV['TRELLO_RESPONSE_PREFIX'] || 'Created'
           message.reply "#{prefix} #{new_card.short_url}"
+        end
+      end
+
+      def find_member(members, sender)
+        senders_to_members = {}
+        if ENV['TRELLO_MEMBER_FROM_SENDER']
+          senders_to_members = JSON.parse(ENV['TRELLO_MEMBER_FROM_SENDER'])
+        end
+        members.find do |member|
+          # SlackのDisplay nameとTrelloのUsername（username）のマッピングと一致
+          return member if member.username.downcase == senders_to_members[sender]
+          # TrelloのUsername（username）と一致
+          return member if member.username.downcase == sender
+          # AtlassianのPublic Name（full_name）と一致
+          return member if member.full_name.downcase == sender
         end
       end
     end

--- a/lib/ruboty/trello/version.rb
+++ b/lib/ruboty/trello/version.rb
@@ -1,5 +1,5 @@
 module Ruboty
   module Trello
-    VERSION = '0.1.5'
+    VERSION = '0.1.6'
   end
 end

--- a/lib/ruboty/trello/version.rb
+++ b/lib/ruboty/trello/version.rb
@@ -1,5 +1,5 @@
 module Ruboty
   module Trello
-    VERSION = '0.1.6'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
SlackからTrelloにカードを追加したときに、誰が追加したかわかるようにしました。
やり方としては、SlackのDisplay nameとTrelloのusernameのマッピングを、Herokuの環境変数で設定できるようにして、カードの追加時にメンバーIDとして付与するようにしています。

Herokuに`TRELLO_MEMBER_FROM_SENDER`という名前で`{"ihara":"masahiroihara", "pocke":"masatakapockekuwabara"}`のようなJSONをつくれば動くはずです。マージする前に変数は設定しておこうと思います。

@bitjourney/engineers お願いします 🙏 