### PR TITLE
Relax dev dependencies

### DIFF
--- a/ruboty-trello.gemspec
+++ b/ruboty-trello.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ruboty'
   spec.add_dependency 'ruby-trello'
-  spec.add_development_dependency 'bundler', '~> 1.11'
-  spec.add_development_dependency 'rake', '~> 11.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
ruboty-trelloのdevelopment dependencyのバージョン指定をゆるくします。 これによってSecurity Alertがなくなります。

バージョンの指定を外しているので、bundler や rake が後方互換性のない変更をするとうまく動かなくなることが懸念されます。
とはいえ古いバージョン指定をアップデートしてまわる方が面倒なので、バージョン指定を外してしまおうと思います。後方互換性のない変更が発生したらその時に考えれば(== バージョン指定を再びつければ)よいと考えています。